### PR TITLE
avoid too many event listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,12 +302,16 @@ class Rs extends Transform {
 			return Promise.resolve();
 		} else {
 			return new Promise((resolve, reject) => {
-				this.ws.once('error', err => reject(err));
+				const fn = err => reject(err);
+				this.ws.once('error', fn);
 				this.ws.once('drain', err => {
-					if (err) return reject(err);
-					
-					resolve();
-				})
+					this.ws.removeListener('error', fn);
+					if (err) {
+						reject(err);
+					} else {
+						resolve();
+					}
+				});
 			});
 		}
 	}


### PR DESCRIPTION
when calling `writeRow` around a million times in a loop I get "MaxListenersExceededWarning: Possible EventEmitter memory leak detected" warning message, because when waiting for 'drain' the code is not removing the 'error' listener it attaches.

This change just removes the attached 'error' listener and avoids the warning, functionality stays the same.